### PR TITLE
fix(appwrite): correct import to use tablesDB instead of databases

### DIFF
--- a/src/routes/docs/tutorials/sveltekit/step-6/+page.markdoc
+++ b/src/routes/docs/tutorials/sveltekit/step-6/+page.markdoc
@@ -35,7 +35,7 @@ Create a new file `src/lib/ideas.js` and add the following code:
 
 ```client-web
 import { ID, Query } from 'appwrite';
-import { databases } from '$lib/appwrite';
+import { tablesDB } from '$lib/appwrite';
 
 const IDEAS_DATABASE_ID = '<YOUR_DATABASE_ID>'; // Replace with your database ID
 const IDEAS_TABLE_ID = '<YOUR_TABLE_ID>'; // Replace with your table ID


### PR DESCRIPTION
### Summary
This PR fixes an incorrect Appwrite import that caused runtime errors.

### Changes
- Updated `appwrite.js` to correctly export:
` export const tablesDB = new TablesDB(client);`
 

- Replaced all invalid imports of:
   ```js 
     import { databases } from '$lib/appwrite';
- with
    ```js 
  import { tablesDB } from '$lib/appwrite'
**Why**

The Appwrite SDK no longer provides a databases export.
Instead, the correct class is TablesDB, which must be instantiated and exported as tablesDB.
Without this fix, the code attempted to import a non-existent databases object, leading to errors when accessing the database.

Additional Notes

No breaking changes to functionality, just corrected the import/export.

Code is now aligned with the latest Appwrite SDK usage.
